### PR TITLE
fix: update leader election id

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,7 +68,7 @@ func main() {
 		Scheme:                 scheme,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "1f172fb1.spectrocloud.labs",
+		LeaderElectionID:       "ecaf1259.spectrocloud.labs",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
The oci validator plugin was hanging just attempting to acquire leader lease on startup when it was installed via the validator helm chart. 

```
attempting to acquire leader lease validator/1f172fb1.spectrocloud.labs...
```

This is because there was a collision in the leader election id between this plugin and the aws plugin.

This PR simply updates the id so that there is no longer any collision.