### PR TITLE
fix: CRD validation for rule host uniqueness

### DIFF
--- a/api/v1alpha1/ocivalidator_types.go
+++ b/api/v1alpha1/ocivalidator_types.go
@@ -17,13 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // OciValidatorSpec defines the desired state of OciValidator
 type OciValidatorSpec struct {
+	// +kubebuilder:validation:MaxItems=5
+	// +kubebuilder:validation:XValidation:message="OciRegistryRules must have a unique Host",rule="self.all(e, size(self.filter(x, x.host == e.host)) == 1)"
 	OciRegistryRules []OciRegistryRule `json:"ociRegistryRules,omitempty" yaml:"ociRegistryRules,omitempty"`
 }
 
@@ -46,7 +46,7 @@ type OciRegistryRule struct {
 }
 
 func (r OciRegistryRule) Name() string {
-	return fmt.Sprintf("%s/%d", r.Host, len(r.Artifacts))
+	return r.Host
 }
 
 type Artifact struct {

--- a/chart/validator-plugin-oci/crds/ocivalidator-crd.yaml
+++ b/chart/validator-plugin-oci/crds/ocivalidator-crd.yaml
@@ -76,7 +76,11 @@ spec:
                   required:
                   - host
                   type: object
+                maxItems: 5
                 type: array
+                x-kubernetes-validations:
+                - message: OciRegistryRules must have a unique Host
+                  rule: self.all(e, size(self.filter(x, x.host == e.host)) == 1)
             type: object
           status:
             description: OciValidatorStatus defines the observed state of OciValidator

--- a/config/crd/bases/validation.spectrocloud.labs_ocivalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_ocivalidators.yaml
@@ -77,7 +77,11 @@ spec:
                   required:
                   - host
                   type: object
+                maxItems: 5
                 type: array
+                x-kubernetes-validations:
+                - message: OciRegistryRules must have a unique Host
+                  rule: self.all(e, size(self.filter(x, x.host == e.host)) == 1)
             type: object
           status:
             description: OciValidatorStatus defines the observed state of OciValidator

--- a/config/samples/ocivalidator-private-registry.yaml
+++ b/config/samples/ocivalidator-private-registry.yaml
@@ -1,7 +1,7 @@
 apiVersion: validation.spectrocloud.labs/v1alpha1
 kind: OciValidator
 metadata:
-  name: ocivalidator-sample-oci-registry
+  name: ocivalidator-sample-private-oci-registries
 spec:
   ociRegistryRules:
     # private oci registry artifacts requiring auth and a caCert

--- a/config/samples/ocivalidator-private-registry.yaml
+++ b/config/samples/ocivalidator-private-registry.yaml
@@ -4,40 +4,18 @@ metadata:
   name: ocivalidator-sample-oci-registry
 spec:
   ociRegistryRules:
-    # artifact on public oci registry
-    - host: "registry-1.docker.io"
-      artifacts:
-        - ref: "bitnamicharts/mysql:9.14.3"
-
-    # list of artifacts on a public oci registry with a caCert. artifacts are referenced and by a specific tag or digest
+    # private oci registry artifacts requiring auth and a caCert
     - host: "oci-airgap.spectrocloud.dev"
       artifacts:
         - ref: "spectro-images/gcr.io/spectro-images-fips/kube-apiserver:v1.26.5"
           download: true
         - ref: "spectro-images/gcr.io/spectro-images-fips/kube-scheduler@sha256:65ae8fd8713ede1977d26991821ba7eb3beb48ec575b31947568f30dbdd36862"
           download: true
-      caCert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURGRENDQWZ5Z0F3SUJBZ0lSQU1IM2F5UWUvYUkwK1Y0OGE0QnlNYVF3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSmFHRnlZbTl5TFdOaE1CNFhEVEl6TURneE9UQXdNRGMwTjFvWERUSTBNRGd4T0RBdwpNRGMwTjFvd0ZERVNNQkFHQTFVRUF4TUphR0Z5WW05eUxXTmhNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DCkFROEFNSUlCQ2dLQ0FRRUFtSTlaOUp4Zmg1SlZ0REMyS1U3WS85K0srSzFGanI1T3ZOUmk1RE1iR3NpZ2t6N2wKR054ZkgwSWdJRFdPZ1Q5L3YvNTJ5N1NZcnNrYWJYRVR1TEs3ajlaTXdXck9ZZm1mckcva1VMK3FlTThPYjZZdQorSUhNV3E4Z3VOdzJ2UW9yK214eW1JRUFTc3ZsTDBzd25vSXVQWk1GbFg5NEpWNUJtR3BtVjFrNmZaSVh2b05nClVUaHFoSE4vUFVIVDNibkxYaGlTdFNCZjBIMFR1U3BLMitEVXpvOFVRdlNvaStyV0k5SXRRRENZemtrWjg0bjIKeEp6WCtHSXlvYjNsdGdXU3ZSYmRURU9VK1pmYm0xVTRMV1U4YjdhVWRZSVdwM1EzSEVZK2F1WG1SbmlRSld2aQpQVUJrNTBUQnVPNFFJSWx0VGtHS3VTM0svR2s2SU0ra2FibUY0d0lEQVFBQm8yRXdYekFPQmdOVkhROEJBZjhFCkJBTUNBcVF3SFFZRFZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01BOEdBMVVkRXdFQi93UUYKTUFNQkFmOHdIUVlEVlIwT0JCWUVGRk4vYkhTS256ZE9IZ0k4d2ttNlpPbnV0eTRxTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRxNk9vRDI2NWF4Y2x3QVg3ZzdTdEtiZFNkeVNNcC9GbEJZOEJTS0QzdUxDWUtJZmRMdnJJClhKa0Z6MUFXa3hLb1dDbyt2RFl2cEUybE42WXAvakRQZUhZd1c3WG1HQTZJZDRVZ2FtdzV2NHhVZXg5Wis0V1IKbzdqNnV1NkVYK0xOdkQzREFSOFk4aEN3S1NDV3JNWURGbWV3Wmh6N05kY1VBcEp5M3phWTZWeHMvS3dlTGxicwpwbHh2TjlIWCtocVZobC8rWkFtbFZOOVZmZkhHblpsZm5tZW5Tb3RSbjJnR3Rmc0VrV3dhR3UvOUNPbTNQZlhTCjNTY0NGZTNNSjBZbjYvcG1iQkFVVnRtRjFUOTNsT2FYZ3VIek1pWEhJdyt4NUhadnhidkRQbmZ0Z0tnQWpWWU0KRmY0ODlRb28yalVuRVNmK2JRZFczcnpjMUFaMndwbmgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
-
-    # list of artifacts on private oci registry requiring auth and a caCert
-    - host: "oci-airgap.spectrocloud.dev"
-      artifacts:
         - ref: "spectro-packs/spectro-packs/archive/vault:0.25.0"
         - ref: "spectro-packs/spectro-packs/archive/spectro-mgmt@sha256:ddbac6e7732bf90a4e674a01bf279ce27ea8691530b8d209e6fe77477e0fa406"
       auth:
         secretName: oci-airgap-credentials
       caCert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURGRENDQWZ5Z0F3SUJBZ0lSQU1IM2F5UWUvYUkwK1Y0OGE0QnlNYVF3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSmFHRnlZbTl5TFdOaE1CNFhEVEl6TURneE9UQXdNRGMwTjFvWERUSTBNRGd4T0RBdwpNRGMwTjFvd0ZERVNNQkFHQTFVRUF4TUphR0Z5WW05eUxXTmhNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DCkFROEFNSUlCQ2dLQ0FRRUFtSTlaOUp4Zmg1SlZ0REMyS1U3WS85K0srSzFGanI1T3ZOUmk1RE1iR3NpZ2t6N2wKR054ZkgwSWdJRFdPZ1Q5L3YvNTJ5N1NZcnNrYWJYRVR1TEs3ajlaTXdXck9ZZm1mckcva1VMK3FlTThPYjZZdQorSUhNV3E4Z3VOdzJ2UW9yK214eW1JRUFTc3ZsTDBzd25vSXVQWk1GbFg5NEpWNUJtR3BtVjFrNmZaSVh2b05nClVUaHFoSE4vUFVIVDNibkxYaGlTdFNCZjBIMFR1U3BLMitEVXpvOFVRdlNvaStyV0k5SXRRRENZemtrWjg0bjIKeEp6WCtHSXlvYjNsdGdXU3ZSYmRURU9VK1pmYm0xVTRMV1U4YjdhVWRZSVdwM1EzSEVZK2F1WG1SbmlRSld2aQpQVUJrNTBUQnVPNFFJSWx0VGtHS3VTM0svR2s2SU0ra2FibUY0d0lEQVFBQm8yRXdYekFPQmdOVkhROEJBZjhFCkJBTUNBcVF3SFFZRFZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01BOEdBMVVkRXdFQi93UUYKTUFNQkFmOHdIUVlEVlIwT0JCWUVGRk4vYkhTS256ZE9IZ0k4d2ttNlpPbnV0eTRxTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRxNk9vRDI2NWF4Y2x3QVg3ZzdTdEtiZFNkeVNNcC9GbEJZOEJTS0QzdUxDWUtJZmRMdnJJClhKa0Z6MUFXa3hLb1dDbyt2RFl2cEUybE42WXAvakRQZUhZd1c3WG1HQTZJZDRVZ2FtdzV2NHhVZXg5Wis0V1IKbzdqNnV1NkVYK0xOdkQzREFSOFk4aEN3S1NDV3JNWURGbWV3Wmh6N05kY1VBcEp5M3phWTZWeHMvS3dlTGxicwpwbHh2TjlIWCtocVZobC8rWkFtbFZOOVZmZkhHblpsZm5tZW5Tb3RSbjJnR3Rmc0VrV3dhR3UvOUNPbTNQZlhTCjNTY0NGZTNNSjBZbjYvcG1iQkFVVnRtRjFUOTNsT2FYZ3VIek1pWEhJdyt4NUhadnhidkRQbmZ0Z0tnQWpWWU0KRmY0ODlRb28yalVuRVNmK2JRZFczcnpjMUFaMndwbmgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
-
-    # artifact on a public oci registry referenced by default "latest" tag
-    - host: "registry.hub.docker.com"
-      artifacts:
-        - ref: "ahmadibraspectrocloud/kubebuilder-cron"
-          download: true
-
-    # artifact on public ecr registry referenced by default "latest" tag
-    - host: "public.ecr.aws"
-      artifacts:
-        - ref: "u5n5j0b4/oci-test-public"
-          download: true
 
     # private ecr registry with no artifact specified
     - host: "745150053801.dkr.ecr.us-east-1.amazonaws.com"

--- a/config/samples/ocivalidator-public-registry.yaml
+++ b/config/samples/ocivalidator-public-registry.yaml
@@ -1,7 +1,7 @@
 apiVersion: validation.spectrocloud.labs/v1alpha1
 kind: OciValidator
 metadata:
-  name: ocivalidator-sample-oci-registry
+  name: ocivalidator-sample-public-oci-registries
 spec:
   ociRegistryRules:
     # public oci registry artifact with tag

--- a/config/samples/ocivalidator-public-registry.yaml
+++ b/config/samples/ocivalidator-public-registry.yaml
@@ -1,0 +1,22 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: OciValidator
+metadata:
+  name: ocivalidator-sample-oci-registry
+spec:
+  ociRegistryRules:
+    # public oci registry artifact with tag
+    - host: "registry-1.docker.io"
+      artifacts:
+        - ref: "bitnamicharts/mysql:9.14.3"
+
+    # public oci registry artifact referenced by default "latest" tag
+    - host: "registry.hub.docker.com"
+      artifacts:
+        - ref: "ahmadibraspectrocloud/kubebuilder-cron"
+          download: true
+
+    # public ecr registry artifact referenced by default "latest" tag
+    - host: "public.ecr.aws"
+      artifacts:
+        - ref: "u5n5j0b4/oci-test-public"
+          download: true

--- a/internal/controller/ocivalidator_controller_test.go
+++ b/internal/controller/ocivalidator_controller_test.go
@@ -33,7 +33,7 @@ var _ = Describe("OCIValidator controller", Ordered, func() {
 		Spec: v1alpha1.OciValidatorSpec{
 			OciRegistryRules: []v1alpha1.OciRegistryRule{
 				{
-					Host:      "foo.registry.io",
+					Host:      "foo1.registry.io",
 					Artifacts: []v1alpha1.Artifact{},
 				},
 				{
@@ -46,7 +46,7 @@ var _ = Describe("OCIValidator controller", Ordered, func() {
 					},
 				},
 				{
-					Host:   "foo.registry.io",
+					Host:   "foo2.registry.io",
 					CaCert: "dummy-ca-cert",
 					Artifacts: []v1alpha1.Artifact{
 						{
@@ -56,7 +56,7 @@ var _ = Describe("OCIValidator controller", Ordered, func() {
 					},
 				},
 				{
-					Host: "foo.registry.io",
+					Host: "foo3.registry.io",
 					Auth: v1alpha1.Auth{
 						SecretName: "mySecret",
 					},


### PR DESCRIPTION
This PR enforces the following:
1. The host in each rule added in a CR is unique
2. There are a max of 5 rules added to each CR