### PR TITLE
fix: ensure codecov is run when code is pushed to main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: Test
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
I noticed that the code coverage hasnt updated since a commit was pushed that removes this code. This should get things working again