### PR TITLE
feat: introduce LayerValidation bool to expose go-containerregistry fast validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Dockerfile.cross
 
 # misc
 .DS_Store
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifneq (,$(wildcard ./.env))
+	include .env
+	export
+endif
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/spectrocloud-labs/validator-plugin-oci:latest

--- a/api/v1alpha1/ocivalidator_types.go
+++ b/api/v1alpha1/ocivalidator_types.go
@@ -59,8 +59,11 @@ type Artifact struct {
 	// When no tag or digest are specified, the default tag "latest" is used.
 	Ref string `json:"ref" yaml:"ref"`
 
-	// Download specifies whether a download attempt should be made for the artifact
-	Download bool `json:"download,omitempty" yaml:"download,omitempty"`
+	// LayerValidation specifies whether deep validation of the artifact layers should be performed.
+	// The existence of layers is always validated, but this option allows for the deep validation of the layers.
+	// See more details here:
+	// https://github.com/google/go-containerregistry/blob/8dadbe76ff8c20d0e509406f04b7eade43baa6c1/pkg/v1/validate/image.go#L105
+	LayerValidation bool `json:"layerValidation,omitempty" yaml:"layerValidation,omitempty"`
 }
 
 type Auth struct {

--- a/config/crd/bases/validation.spectrocloud.labs_ocivalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_ocivalidators.yaml
@@ -42,9 +42,12 @@ spec:
                         that should be validated.
                       items:
                         properties:
-                          download:
-                            description: Download specifies whether a download attempt
-                              should be made for the artifact
+                          layerValidation:
+                            description: 'LayerValidation specifies whether deep validation
+                              of the artifact layers should be performed. The existence
+                              of layers is always validated, but this option allows
+                              for the deep validation of the layers. See more details
+                              here: https://github.com/google/go-containerregistry/blob/8dadbe76ff8c20d0e509406f04b7eade43baa6c1/pkg/v1/validate/image.go#L105'
                             type: boolean
                           ref:
                             description: "Ref is the path to the artifact in the host

--- a/config/samples/ocivalidator-private-registry.yaml
+++ b/config/samples/ocivalidator-private-registry.yaml
@@ -8,9 +8,9 @@ spec:
     - host: "oci-airgap.spectrocloud.dev"
       artifacts:
         - ref: "spectro-images/gcr.io/spectro-images-fips/kube-apiserver:v1.26.5"
-          download: true
+          layerValidation: true
         - ref: "spectro-images/gcr.io/spectro-images-fips/kube-scheduler@sha256:65ae8fd8713ede1977d26991821ba7eb3beb48ec575b31947568f30dbdd36862"
-          download: true
+          layerValidation: true
         - ref: "spectro-packs/spectro-packs/archive/vault:0.25.0"
         - ref: "spectro-packs/spectro-packs/archive/spectro-mgmt@sha256:ddbac6e7732bf90a4e674a01bf279ce27ea8691530b8d209e6fe77477e0fa406"
       auth:

--- a/config/samples/ocivalidator-public-registry.yaml
+++ b/config/samples/ocivalidator-public-registry.yaml
@@ -5,18 +5,19 @@ metadata:
 spec:
   ociRegistryRules:
     # public oci registry artifact with tag
-    - host: "registry-1.docker.io"
+    - host: "docker.io"
       artifacts:
-        - ref: "bitnamicharts/mysql:9.14.3"
+        - ref: "library/redis:7.2.4"
+          layerValidation: true
 
     # public oci registry artifact referenced by default "latest" tag
     - host: "registry.hub.docker.com"
       artifacts:
         - ref: "ahmadibraspectrocloud/kubebuilder-cron"
-          download: true
+          layerValidation: true
 
     # public ecr registry artifact referenced by default "latest" tag
     - host: "public.ecr.aws"
       artifacts:
         - ref: "u5n5j0b4/oci-test-public"
-          download: true
+          layerValidation: true

--- a/internal/controller/ocivalidator_controller.go
+++ b/internal/controller/ocivalidator_controller.go
@@ -75,9 +75,10 @@ func (r *OciValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
+	ociRuleService := val.NewOciRuleService(r.Log)
+
 	// OCI Registry rules
 	for _, rule := range validator.Spec.OciRegistryRules {
-		ociRuleService := val.NewOciRuleService(r.Log)
 		username, password := r.secretKeyAuth(req, rule)
 
 		validationResult, err := ociRuleService.ReconcileOciRegistryRule(rule, username, password)

--- a/internal/controller/ocivalidator_controller_test.go
+++ b/internal/controller/ocivalidator_controller_test.go
@@ -40,8 +40,8 @@ var _ = Describe("OCIValidator controller", Ordered, func() {
 					Host: "foo.registry.io",
 					Artifacts: []v1alpha1.Artifact{
 						{
-							Ref:      "foo/bar:latest",
-							Download: true,
+							Ref:             "foo/bar:latest",
+							LayerValidation: true,
 						},
 					},
 				},
@@ -50,8 +50,8 @@ var _ = Describe("OCIValidator controller", Ordered, func() {
 					CaCert: "dummy-ca-cert",
 					Artifacts: []v1alpha1.Artifact{
 						{
-							Ref:      "foo/bar:latest",
-							Download: true,
+							Ref:             "foo/bar:latest",
+							LayerValidation: true,
 						},
 					},
 				},
@@ -62,8 +62,8 @@ var _ = Describe("OCIValidator controller", Ordered, func() {
 					},
 					Artifacts: []v1alpha1.Artifact{
 						{
-							Ref:      "foo/bar:latest",
-							Download: true,
+							Ref:             "foo/bar:latest",
+							LayerValidation: true,
 						},
 					},
 				},

--- a/internal/controller/ocivalidator_controller_test.go
+++ b/internal/controller/ocivalidator_controller_test.go
@@ -62,8 +62,7 @@ var _ = Describe("OCIValidator controller", Ordered, func() {
 					},
 					Artifacts: []v1alpha1.Artifact{
 						{
-							Ref:             "foo/bar:latest",
-							LayerValidation: true,
+							Ref: "foo/bar:latest",
 						},
 					},
 				},

--- a/internal/validators/oci_validator_test.go
+++ b/internal/validators/oci_validator_test.go
@@ -242,35 +242,35 @@ func TestValidateReference(t *testing.T) {
 	}
 
 	type testCase struct {
-		ref            name.Reference
-		download       bool
-		expectedDetail string
-		expectErr      bool
+		ref             name.Reference
+		layerValidation bool
+		expectedDetail  string
+		expectErr       bool
 	}
 
 	testCases := []testCase{
 		{
-			ref:            validRef,
-			download:       false,
-			expectedDetail: "",
-			expectErr:      false,
+			ref:             validRef,
+			layerValidation: false,
+			expectedDetail:  "",
+			expectErr:       false,
 		},
 		{
-			ref:            validRef,
-			download:       true,
-			expectedDetail: "",
-			expectErr:      false,
+			ref:             validRef,
+			layerValidation: true,
+			expectedDetail:  "",
+			expectErr:       false,
 		},
 		{
-			ref:            invalidRef,
-			download:       false,
-			expectedDetail: "failed to get descriptor for artifact",
-			expectErr:      true,
+			ref:             invalidRef,
+			layerValidation: false,
+			expectedDetail:  "failed to get descriptor for artifact",
+			expectErr:       true,
 		},
 	}
 
 	for _, tc := range testCases {
-		detail, err := validateReference(tc.ref, tc.download, []remote.Option{remote.WithAuth(authn.Anonymous)})
+		detail, err := validateReference(tc.ref, tc.layerValidation, []remote.Option{remote.WithAuth(authn.Anonymous)})
 
 		if tc.expectErr {
 			assert.NotNil(t, err)


### PR DESCRIPTION
This PR introduces a new LayerValidation bool which is used to expose the go-containerregistry fast validation.

Aside from that change, i've also updated the validator to always download artifacts rather than optionally download them.