### PR TITLE
fix: ensure error is returned when signature verification is enabled but pubkeys is an empty slice

### DIFF
--- a/internal/validators/oci_validator_test.go
+++ b/internal/validators/oci_validator_test.go
@@ -275,7 +275,14 @@ func TestValidateReference(t *testing.T) {
 			ref:             validRef,
 			layerValidation: true,
 			pubKeys:         [][]byte{[]byte("invalid-pub-key-1"), []byte("invalid-pub-key-2")},
-			expectedDetail:  "failed to verify signature for artifact",
+			expectedDetail:  "failed to create verifier with public key",
+			expectErr:       true,
+		},
+		{
+			ref:             validRef,
+			layerValidation: true,
+			pubKeys:         [][]byte{},
+			expectedDetail:  "no matching signatures were found",
 			expectErr:       true,
 		},
 		{
@@ -287,7 +294,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKPuCo9AmJCpqGWhefjbhkFcr1GA3
 iNa765seE3jYC3MGUe5h52393Dhy7B5bXGsg6EfPpNYamlAEWjxCpHF3Lg==
 -----END PUBLIC KEY-----`),
 			},
-			expectedDetail: "failed to verify signature for artifact",
+			expectedDetail: "no matching signatures were found",
 			expectErr:      true,
 		},
 	}


### PR DESCRIPTION
- Ensures an error is propagated when an empty slice of pubkeys is provided (previously just a detail was added and the validation result's state would be success)
- Also adds a test case covering this failed state
- Cleans up some details that were showing up multiple times in the validation results